### PR TITLE
Fix: Displays images with incorrect aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       src="/images/logo.webp"
       alt="Logo showing an dwarf with a tankard of beer"
       width="256px"
-      height="351px"
+      height="348px"
     >
   </a>
 </header>
@@ -189,7 +189,7 @@
       src="/images/logo.webp"
       alt="Logo showing an dwarf with a tankard of beer"
       width="256px"
-      height="351px"
+      height="348px"
     >
   </a>
   <p class="footer__text" x-data x-text="new Date().getFullYear()"></p>


### PR DESCRIPTION
Fix "Displays images with incorrect aspect ratio" that is flagged in the Lighthouse report on Netlify.